### PR TITLE
Enable ZMQ for Bitcoin Core 29

### DIFF
--- a/29.0/Dockerfile
+++ b/29.0/Dockerfile
@@ -251,6 +251,7 @@ RUN cmake -S . -B build \
     -DBUILD_BENCH=OFF \
     -DBUILD_GUI=OFF \
     -DWITH_SQLITE=ON \
+    -DWITH_ZMQ=ON \
     -DWITH_CCACHE=OFF
 
 RUN cmake --build build -- -j$(( $(nproc) + 1 ))


### PR DESCRIPTION
If ZMQ is not explicitly enabled, it will not be available. ZMQ is often used, for example by LND, so I think it makes sense to enable it.