### PR TITLE
Update README with version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ This repo builds [`bitcoind`] in an [auditable way](https://github.com/lnliz/doc
 
 ## Available Versions
 
+### Latest version
+
+* `knots-latest` (latest current version of Bitcoin Knots)
+* `core-latest` (latest current version of Bitcoin Core)
+* `inq-latest` (latest current version of Bitcoin Inquisition )
+
+### Specific version
+
 > **NOTE:** For an always up-to-date list see: https://hub.docker.com/r/lnliz/bitcoind/tags
 
 * `v31.0` (most current)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repo builds [`bitcoind`] in an [auditable way](https://github.com/lnliz/doc
 
 * `knots-latest` (latest current version of Bitcoin Knots)
 * `core-latest` (latest current version of Bitcoin Core)
-* `inq-latest` (latest current version of Bitcoin Inquisition )
+* `inq-latest` (latest current version of Bitcoin Inquisition)
 
 ### Specific version
 


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the available Docker image versions for `bitcoind`. It adds a section listing both the latest and specific tags for Bitcoin Knots, Bitcoin Core, and Bitcoin Inquisition.

Documentation improvements:

* Added a new "Available Versions" section to the `README.md`, listing tags for the latest versions (`knots-latest`, `core-latest`, `inq-latest`) and clarifying usage of specific version tags like `v31.0`.